### PR TITLE
Add a plus sign (+) to the FollowSymLinks option

### DIFF
--- a/tools/guinux/snpservices.conf
+++ b/tools/guinux/snpservices.conf
@@ -1,6 +1,6 @@
 Alias /snpservices /usr/share/snpservices
 
 <Directory "/usr/share/snpservices">
-    Options FollowSymLinks -Multiviews
+    Options +FollowSymLinks -Multiviews
     AllowOverride None
 </Directory>


### PR DESCRIPTION
This commit makes the snpservices.conf file compatible with Apache 2.4. From this version on, either all options must start with + or -, or none of them may. Therefore a + must be added to FollowSymLinks.
